### PR TITLE
Add capability config and practice lead auth

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -67,12 +67,14 @@ All data is currently stored in memory for this learning exercise. In a producti
 
 Capability definitions are stored in `capabilities.json` alongside the API code. Update that file to add or edit capabilities without changing `app.py`.
 
-Practice lead credentials are stored in `practice_leads.json`. The app now requires practice lead authentication before consultants can be removed from a capability.
+Practice lead identities are stored in `practice_leads.json`. Passwords are read from environment variables named in that file, so secrets do not need to be committed to the repository.
 
-Demo practice lead accounts for local testing:
+For local testing, set the password environment variables before starting the app. Example:
 
-- Username: `practicelead-tech` Password: `slalom-tech-lead`
-- Username: `practicelead-strategy` Password: `slalom-strategy-lead`
+- `export PRACTICELEAD_TECH_PASSWORD='choose-a-strong-password'`
+- `export PRACTICELEAD_STRATEGY_PASSWORD='choose-a-strong-password'`
+
+Capability and practice lead configuration is loaded from disk on each request, so updates to those JSON files are reflected without restarting the app.
 
 ## Future Enhancements
 

--- a/src/README.md
+++ b/src/README.md
@@ -74,6 +74,8 @@ For local testing, set the password environment variables before starting the ap
 - `export PRACTICELEAD_TECH_PASSWORD='choose-a-strong-password'`
 - `export PRACTICELEAD_STRATEGY_PASSWORD='choose-a-strong-password'`
 
+If those environment variables are missing, practice lead login returns `503` to indicate the server is not configured for authenticated access yet.
+
 Capability and practice lead configuration is loaded from disk on each request, so updates to those JSON files are reflected without restarting the app.
 
 ## Future Enhancements

--- a/src/README.md
+++ b/src/README.md
@@ -63,6 +63,17 @@ The application uses a consulting-focused data model:
 
 All data is currently stored in memory for this learning exercise. In a production environment, this would be backed by a robust database system.
 
+## Configuration
+
+Capability definitions are stored in `capabilities.json` alongside the API code. Update that file to add or edit capabilities without changing `app.py`.
+
+Practice lead credentials are stored in `practice_leads.json`. The app now requires practice lead authentication before consultants can be removed from a capability.
+
+Demo practice lead accounts for local testing:
+
+- Username: `practicelead-tech` Password: `slalom-tech-lead`
+- Username: `practicelead-strategy` Password: `slalom-strategy-lead`
+
 ## Future Enhancements
 
 This exercise will guide you through implementing:

--- a/src/app.py
+++ b/src/app.py
@@ -6,8 +6,6 @@ capabilities and manage consulting expertise across the organization.
 """
 
 import json
-import base64
-import hashlib
 import hmac
 import os
 import secrets
@@ -57,15 +55,12 @@ def save_capabilities(updated_capabilities):
 
 
 def verify_password(password: str, practice_lead: dict):
-    salt = base64.b64decode(practice_lead["password_salt"])
-    expected_hash = base64.b64decode(practice_lead["password_hash"])
-    candidate_hash = hashlib.pbkdf2_hmac(
-        "sha256",
-        password.encode("utf-8"),
-        salt,
-        200000
-    )
-    return hmac.compare_digest(candidate_hash, expected_hash)
+    expected_password = os.getenv(practice_lead["password_env_var"])
+
+    if not expected_password:
+        return False
+
+    return hmac.compare_digest(password, expected_password)
 
 
 def build_session_user(username: str, practice_lead: dict):
@@ -79,6 +74,7 @@ def build_session_user(username: str, practice_lead: dict):
 def get_authenticated_practice_lead(request: Request):
     session_token = request.cookies.get(session_cookie_name)
     username = auth_sessions.get(session_token)
+    practice_leads = load_practice_leads()
 
     if not username or username not in practice_leads:
         raise HTTPException(status_code=401, detail="Practice lead authentication required")
@@ -95,9 +91,6 @@ def can_manage_capability(practice_lead: dict, capability: dict):
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-capabilities = load_capabilities()
-practice_leads = load_practice_leads()
-
 
 @app.get("/")
 def root():
@@ -106,13 +99,14 @@ def root():
 
 @app.get("/capabilities")
 def get_capabilities():
-    return capabilities
+    return load_capabilities()
 
 
 @app.get("/auth/session")
 def get_auth_session(request: Request):
     session_token = request.cookies.get(session_cookie_name)
     username = auth_sessions.get(session_token)
+    practice_leads = load_practice_leads()
 
     if not username or username not in practice_leads:
         return {"authenticated": False}
@@ -125,6 +119,7 @@ def get_auth_session(request: Request):
 
 @app.post("/auth/login")
 def login(login_request: LoginRequest, response: Response):
+    practice_leads = load_practice_leads()
     practice_lead = practice_leads.get(login_request.username)
 
     if not practice_lead or not verify_password(login_request.password, practice_lead):
@@ -160,6 +155,8 @@ def logout(request: Request, response: Response):
 @app.post("/capabilities/{capability_name}/register")
 def register_for_capability(capability_name: str, email: str):
     """Register a consultant for a capability"""
+    capabilities = load_capabilities()
+
     # Validate capability exists
     if capability_name not in capabilities:
         raise HTTPException(status_code=404, detail="Capability not found")
@@ -183,6 +180,8 @@ def register_for_capability(capability_name: str, email: str):
 @app.delete("/capabilities/{capability_name}/unregister")
 def unregister_from_capability(capability_name: str, email: str, request: Request):
     """Unregister a consultant from a capability"""
+    capabilities = load_capabilities()
+
     # Validate capability exists
     if capability_name not in capabilities:
         raise HTTPException(status_code=404, detail="Capability not found")

--- a/src/app.py
+++ b/src/app.py
@@ -5,104 +5,98 @@ A FastAPI application that enables Slalom consultants to register their
 capabilities and manage consulting expertise across the organization.
 """
 
-from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
+import json
+import base64
+import hashlib
+import hmac
 import os
+import secrets
 from pathlib import Path
+
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.responses import RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
 
 app = FastAPI(title="Slalom Capabilities Management API",
               description="API for managing consulting capabilities and consultant expertise")
 
-# Mount the static files directory
 current_dir = Path(__file__).parent
+capabilities_file = current_dir / "capabilities.json"
+practice_leads_file = current_dir / "practice_leads.json"
+session_cookie_name = "slalom_session"
+auth_sessions = {}
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+def load_json_file(file_path: Path):
+    with file_path.open("r", encoding="utf-8") as file_handle:
+        return json.load(file_handle)
+
+
+def save_json_file(file_path: Path, data):
+    with file_path.open("w", encoding="utf-8") as file_handle:
+        json.dump(data, file_handle, indent=2)
+        file_handle.write("\n")
+
+
+def load_capabilities():
+    return load_json_file(capabilities_file)
+
+
+def load_practice_leads():
+    return load_json_file(practice_leads_file)
+
+
+def save_capabilities(updated_capabilities):
+    save_json_file(capabilities_file, updated_capabilities)
+
+
+def verify_password(password: str, practice_lead: dict):
+    salt = base64.b64decode(practice_lead["password_salt"])
+    expected_hash = base64.b64decode(practice_lead["password_hash"])
+    candidate_hash = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        salt,
+        200000
+    )
+    return hmac.compare_digest(candidate_hash, expected_hash)
+
+
+def build_session_user(username: str, practice_lead: dict):
+    return {
+        "username": username,
+        "role": practice_lead["role"],
+        "practice_areas": practice_lead["practice_areas"]
+    }
+
+
+def get_authenticated_practice_lead(request: Request):
+    session_token = request.cookies.get(session_cookie_name)
+    username = auth_sessions.get(session_token)
+
+    if not username or username not in practice_leads:
+        raise HTTPException(status_code=401, detail="Practice lead authentication required")
+
+    return build_session_user(username, practice_leads[username])
+
+
+def can_manage_capability(practice_lead: dict, capability: dict):
+    practice_areas = practice_lead["practice_areas"]
+    return "All" in practice_areas or capability.get("practice_area") in practice_areas
+
+
+# Mount the static files directory
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory capabilities database
-capabilities = {
-    "Cloud Architecture": {
-        "description": "Design and implement scalable cloud solutions using AWS, Azure, and GCP",
-        "practice_area": "Technology",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
-        "certifications": ["AWS Solutions Architect", "Azure Architect Expert"],
-        "industry_verticals": ["Healthcare", "Financial Services", "Retail"],
-        "capacity": 40,  # hours per week available across team
-        "consultants": ["alice.smith@slalom.com", "bob.johnson@slalom.com"]
-    },
-    "Data Analytics": {
-        "description": "Advanced data analysis, visualization, and machine learning solutions",
-        "practice_area": "Technology", 
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
-        "certifications": ["Tableau Desktop Specialist", "Power BI Expert", "Google Analytics"],
-        "industry_verticals": ["Retail", "Healthcare", "Manufacturing"],
-        "capacity": 35,
-        "consultants": ["emma.davis@slalom.com", "sophia.wilson@slalom.com"]
-    },
-    "DevOps Engineering": {
-        "description": "CI/CD pipeline design, infrastructure automation, and containerization",
-        "practice_area": "Technology",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"], 
-        "certifications": ["Docker Certified Associate", "Kubernetes Admin", "Jenkins Certified"],
-        "industry_verticals": ["Technology", "Financial Services"],
-        "capacity": 30,
-        "consultants": ["john.brown@slalom.com", "olivia.taylor@slalom.com"]
-    },
-    "Digital Strategy": {
-        "description": "Digital transformation planning and strategic technology roadmaps",
-        "practice_area": "Strategy",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
-        "certifications": ["Digital Transformation Certificate", "Agile Certified Practitioner"],
-        "industry_verticals": ["Healthcare", "Financial Services", "Government"],
-        "capacity": 25,
-        "consultants": ["liam.anderson@slalom.com", "noah.martinez@slalom.com"]
-    },
-    "Change Management": {
-        "description": "Organizational change leadership and adoption strategies",
-        "practice_area": "Operations",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
-        "certifications": ["Prosci Certified", "Lean Six Sigma Black Belt"],
-        "industry_verticals": ["Healthcare", "Manufacturing", "Government"],
-        "capacity": 20,
-        "consultants": ["ava.garcia@slalom.com", "mia.rodriguez@slalom.com"]
-    },
-    "UX/UI Design": {
-        "description": "User experience design and digital product innovation",
-        "practice_area": "Technology",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
-        "certifications": ["Adobe Certified Expert", "Google UX Design Certificate"],
-        "industry_verticals": ["Retail", "Healthcare", "Technology"],
-        "capacity": 30,
-        "consultants": ["amelia.lee@slalom.com", "harper.white@slalom.com"]
-    },
-    "Cybersecurity": {
-        "description": "Information security strategy, risk assessment, and compliance",
-        "practice_area": "Technology",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
-        "certifications": ["CISSP", "CISM", "CompTIA Security+"],
-        "industry_verticals": ["Financial Services", "Healthcare", "Government"],
-        "capacity": 25,
-        "consultants": ["ella.clark@slalom.com", "scarlett.lewis@slalom.com"]
-    },
-    "Business Intelligence": {
-        "description": "Enterprise reporting, data warehousing, and business analytics",
-        "practice_area": "Technology",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
-        "certifications": ["Microsoft BI Certification", "Qlik Sense Certified"],
-        "industry_verticals": ["Retail", "Manufacturing", "Financial Services"],
-        "capacity": 35,
-        "consultants": ["james.walker@slalom.com", "benjamin.hall@slalom.com"]
-    },
-    "Agile Coaching": {
-        "description": "Agile transformation and team coaching for scaled delivery",
-        "practice_area": "Operations",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
-        "certifications": ["Certified Scrum Master", "SAFe Agilist", "ICAgile Certified"],
-        "industry_verticals": ["Technology", "Financial Services", "Healthcare"],
-        "capacity": 20,
-        "consultants": ["charlotte.young@slalom.com", "henry.king@slalom.com"]
-    }
-}
+capabilities = load_capabilities()
+practice_leads = load_practice_leads()
 
 
 @app.get("/")
@@ -113,6 +107,54 @@ def root():
 @app.get("/capabilities")
 def get_capabilities():
     return capabilities
+
+
+@app.get("/auth/session")
+def get_auth_session(request: Request):
+    session_token = request.cookies.get(session_cookie_name)
+    username = auth_sessions.get(session_token)
+
+    if not username or username not in practice_leads:
+        return {"authenticated": False}
+
+    return {
+        "authenticated": True,
+        "user": build_session_user(username, practice_leads[username])
+    }
+
+
+@app.post("/auth/login")
+def login(login_request: LoginRequest, response: Response):
+    practice_lead = practice_leads.get(login_request.username)
+
+    if not practice_lead or not verify_password(login_request.password, practice_lead):
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    session_token = secrets.token_urlsafe(32)
+    auth_sessions[session_token] = login_request.username
+    response.set_cookie(
+        key=session_cookie_name,
+        value=session_token,
+        httponly=True,
+        samesite="lax",
+        max_age=8 * 60 * 60
+    )
+
+    return {
+        "message": "Practice lead signed in",
+        "user": build_session_user(login_request.username, practice_lead)
+    }
+
+
+@app.post("/auth/logout")
+def logout(request: Request, response: Response):
+    session_token = request.cookies.get(session_cookie_name)
+
+    if session_token:
+        auth_sessions.pop(session_token, None)
+
+    response.delete_cookie(session_cookie_name)
+    return {"message": "Signed out"}
 
 
 @app.post("/capabilities/{capability_name}/register")
@@ -134,11 +176,12 @@ def register_for_capability(capability_name: str, email: str):
 
     # Add consultant
     capability["consultants"].append(email)
+    save_capabilities(capabilities)
     return {"message": f"Registered {email} for {capability_name}"}
 
 
 @app.delete("/capabilities/{capability_name}/unregister")
-def unregister_from_capability(capability_name: str, email: str):
+def unregister_from_capability(capability_name: str, email: str, request: Request):
     """Unregister a consultant from a capability"""
     # Validate capability exists
     if capability_name not in capabilities:
@@ -146,6 +189,13 @@ def unregister_from_capability(capability_name: str, email: str):
 
     # Get the specific capability
     capability = capabilities[capability_name]
+    practice_lead = get_authenticated_practice_lead(request)
+
+    if not can_manage_capability(practice_lead, capability):
+        raise HTTPException(
+            status_code=403,
+            detail="You do not have permission to manage this practice area"
+        )
 
     # Validate consultant is registered
     if email not in capability["consultants"]:
@@ -156,4 +206,5 @@ def unregister_from_capability(capability_name: str, email: str):
 
     # Remove consultant
     capability["consultants"].remove(email)
+    save_capabilities(capabilities)
     return {"message": f"Unregistered {email} from {capability_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -9,7 +9,9 @@ import json
 import hmac
 import os
 import secrets
+import tempfile
 from pathlib import Path
+from threading import RLock
 
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
@@ -24,6 +26,7 @@ capabilities_file = current_dir / "capabilities.json"
 practice_leads_file = current_dir / "practice_leads.json"
 session_cookie_name = "slalom_session"
 auth_sessions = {}
+config_lock = RLock()
 
 
 class LoginRequest(BaseModel):
@@ -32,14 +35,24 @@ class LoginRequest(BaseModel):
 
 
 def load_json_file(file_path: Path):
-    with file_path.open("r", encoding="utf-8") as file_handle:
-        return json.load(file_handle)
+    with config_lock:
+        with file_path.open("r", encoding="utf-8") as file_handle:
+            return json.load(file_handle)
 
 
 def save_json_file(file_path: Path, data):
-    with file_path.open("w", encoding="utf-8") as file_handle:
-        json.dump(data, file_handle, indent=2)
-        file_handle.write("\n")
+    with config_lock:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=file_path.parent,
+            delete=False,
+        ) as file_handle:
+            json.dump(data, file_handle, indent=2)
+            file_handle.write("\n")
+            temporary_path = Path(file_handle.name)
+
+        os.replace(temporary_path, file_path)
 
 
 def load_capabilities():
@@ -57,8 +70,8 @@ def save_capabilities(updated_capabilities):
 def verify_password(password: str, practice_lead: dict):
     expected_password = os.getenv(practice_lead["password_env_var"])
 
-    if not expected_password:
-        return False
+    if expected_password is None:
+        return None
 
     return hmac.compare_digest(password, expected_password)
 
@@ -122,7 +135,18 @@ def login(login_request: LoginRequest, response: Response):
     practice_leads = load_practice_leads()
     practice_lead = practice_leads.get(login_request.username)
 
-    if not practice_lead or not verify_password(login_request.password, practice_lead):
+    if not practice_lead:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    password_is_valid = verify_password(login_request.password, practice_lead)
+
+    if password_is_valid is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Practice lead authentication is not configured on the server"
+        )
+
+    if not password_is_valid:
         raise HTTPException(status_code=401, detail="Invalid username or password")
 
     session_token = secrets.token_urlsafe(32)
@@ -155,55 +179,59 @@ def logout(request: Request, response: Response):
 @app.post("/capabilities/{capability_name}/register")
 def register_for_capability(capability_name: str, email: str):
     """Register a consultant for a capability"""
-    capabilities = load_capabilities()
+    with config_lock:
+        capabilities = load_capabilities()
 
-    # Validate capability exists
-    if capability_name not in capabilities:
-        raise HTTPException(status_code=404, detail="Capability not found")
+        # Validate capability exists
+        if capability_name not in capabilities:
+            raise HTTPException(status_code=404, detail="Capability not found")
 
-    # Get the specific capability
-    capability = capabilities[capability_name]
+        # Get the specific capability
+        capability = capabilities[capability_name]
 
-    # Validate consultant is not already registered
-    if email in capability["consultants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Consultant is already registered for this capability"
-        )
+        # Validate consultant is not already registered
+        if email in capability["consultants"]:
+            raise HTTPException(
+                status_code=400,
+                detail="Consultant is already registered for this capability"
+            )
 
-    # Add consultant
-    capability["consultants"].append(email)
-    save_capabilities(capabilities)
+        # Add consultant
+        capability["consultants"].append(email)
+        save_capabilities(capabilities)
+
     return {"message": f"Registered {email} for {capability_name}"}
 
 
 @app.delete("/capabilities/{capability_name}/unregister")
 def unregister_from_capability(capability_name: str, email: str, request: Request):
     """Unregister a consultant from a capability"""
-    capabilities = load_capabilities()
+    with config_lock:
+        capabilities = load_capabilities()
 
-    # Validate capability exists
-    if capability_name not in capabilities:
-        raise HTTPException(status_code=404, detail="Capability not found")
+        # Validate capability exists
+        if capability_name not in capabilities:
+            raise HTTPException(status_code=404, detail="Capability not found")
 
-    # Get the specific capability
-    capability = capabilities[capability_name]
-    practice_lead = get_authenticated_practice_lead(request)
+        # Get the specific capability
+        capability = capabilities[capability_name]
+        practice_lead = get_authenticated_practice_lead(request)
 
-    if not can_manage_capability(practice_lead, capability):
-        raise HTTPException(
-            status_code=403,
-            detail="You do not have permission to manage this practice area"
-        )
+        if not can_manage_capability(practice_lead, capability):
+            raise HTTPException(
+                status_code=403,
+                detail="You do not have permission to manage this practice area"
+            )
 
-    # Validate consultant is registered
-    if email not in capability["consultants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Consultant is not registered for this capability"
-        )
+        # Validate consultant is registered
+        if email not in capability["consultants"]:
+            raise HTTPException(
+                status_code=400,
+                detail="Consultant is not registered for this capability"
+            )
 
-    # Remove consultant
-    capability["consultants"].remove(email)
-    save_capabilities(capabilities)
+        # Remove consultant
+        capability["consultants"].remove(email)
+        save_capabilities(capabilities)
+
     return {"message": f"Unregistered {email} from {capability_name}"}

--- a/src/capabilities.json
+++ b/src/capabilities.json
@@ -1,0 +1,246 @@
+{
+  "Cloud Architecture": {
+    "description": "Design and implement scalable cloud solutions using AWS, Azure, and GCP",
+    "practice_area": "Technology",
+    "skill_levels": [
+      "Emerging",
+      "Proficient",
+      "Advanced",
+      "Expert"
+    ],
+    "certifications": [
+      "AWS Solutions Architect",
+      "Azure Architect Expert"
+    ],
+    "industry_verticals": [
+      "Healthcare",
+      "Financial Services",
+      "Retail"
+    ],
+    "capacity": 40,
+    "consultants": [
+      "bob.johnson@slalom.com",
+      "alice.smith@slalom.com"
+    ]
+  },
+  "Data Analytics": {
+    "description": "Advanced data analysis, visualization, and machine learning solutions",
+    "practice_area": "Technology",
+    "skill_levels": [
+      "Emerging",
+      "Proficient",
+      "Advanced",
+      "Expert"
+    ],
+    "certifications": [
+      "Tableau Desktop Specialist",
+      "Power BI Expert",
+      "Google Analytics"
+    ],
+    "industry_verticals": [
+      "Retail",
+      "Healthcare",
+      "Manufacturing"
+    ],
+    "capacity": 35,
+    "consultants": [
+      "emma.davis@slalom.com",
+      "sophia.wilson@slalom.com"
+    ]
+  },
+  "DevOps Engineering": {
+    "description": "CI/CD pipeline design, infrastructure automation, and containerization",
+    "practice_area": "Technology",
+    "skill_levels": [
+      "Emerging",
+      "Proficient",
+      "Advanced",
+      "Expert"
+    ],
+    "certifications": [
+      "Docker Certified Associate",
+      "Kubernetes Admin",
+      "Jenkins Certified"
+    ],
+    "industry_verticals": [
+      "Technology",
+      "Financial Services"
+    ],
+    "capacity": 30,
+    "consultants": [
+      "john.brown@slalom.com",
+      "olivia.taylor@slalom.com"
+    ]
+  },
+  "Digital Strategy": {
+    "description": "Digital transformation planning and strategic technology roadmaps",
+    "practice_area": "Strategy",
+    "skill_levels": [
+      "Emerging",
+      "Proficient",
+      "Advanced",
+      "Expert"
+    ],
+    "certifications": [
+      "Digital Transformation Certificate",
+      "Agile Certified Practitioner"
+    ],
+    "industry_verticals": [
+      "Healthcare",
+      "Financial Services",
+      "Government"
+    ],
+    "capacity": 25,
+    "consultants": [
+      "liam.anderson@slalom.com",
+      "noah.martinez@slalom.com"
+    ]
+  },
+  "Change Management": {
+    "description": "Organizational change leadership and adoption strategies",
+    "practice_area": "Operations",
+    "skill_levels": [
+      "Emerging",
+      "Proficient",
+      "Advanced",
+      "Expert"
+    ],
+    "certifications": [
+      "Prosci Certified",
+      "Lean Six Sigma Black Belt"
+    ],
+    "industry_verticals": [
+      "Healthcare",
+      "Manufacturing",
+      "Government"
+    ],
+    "capacity": 20,
+    "consultants": [
+      "ava.garcia@slalom.com",
+      "mia.rodriguez@slalom.com"
+    ]
+  },
+  "UX/UI Design": {
+    "description": "User experience design and digital product innovation",
+    "practice_area": "Technology",
+    "skill_levels": [
+      "Emerging",
+      "Proficient",
+      "Advanced",
+      "Expert"
+    ],
+    "certifications": [
+      "Adobe Certified Expert",
+      "Google UX Design Certificate"
+    ],
+    "industry_verticals": [
+      "Retail",
+      "Healthcare",
+      "Technology"
+    ],
+    "capacity": 30,
+    "consultants": [
+      "amelia.lee@slalom.com",
+      "harper.white@slalom.com"
+    ]
+  },
+  "Cybersecurity": {
+    "description": "Information security strategy, risk assessment, and compliance",
+    "practice_area": "Technology",
+    "skill_levels": [
+      "Emerging",
+      "Proficient",
+      "Advanced",
+      "Expert"
+    ],
+    "certifications": [
+      "CISSP",
+      "CISM",
+      "CompTIA Security+"
+    ],
+    "industry_verticals": [
+      "Financial Services",
+      "Healthcare",
+      "Government"
+    ],
+    "capacity": 25,
+    "consultants": [
+      "ella.clark@slalom.com",
+      "scarlett.lewis@slalom.com"
+    ]
+  },
+  "Business Intelligence": {
+    "description": "Enterprise reporting, data warehousing, and business analytics",
+    "practice_area": "Technology",
+    "skill_levels": [
+      "Emerging",
+      "Proficient",
+      "Advanced",
+      "Expert"
+    ],
+    "certifications": [
+      "Microsoft BI Certification",
+      "Qlik Sense Certified"
+    ],
+    "industry_verticals": [
+      "Retail",
+      "Manufacturing",
+      "Financial Services"
+    ],
+    "capacity": 35,
+    "consultants": [
+      "james.walker@slalom.com",
+      "benjamin.hall@slalom.com"
+    ]
+  },
+  "Agile Coaching": {
+    "description": "Agile transformation and team coaching for scaled delivery",
+    "practice_area": "Operations",
+    "skill_levels": [
+      "Emerging",
+      "Proficient",
+      "Advanced",
+      "Expert"
+    ],
+    "certifications": [
+      "Certified Scrum Master",
+      "SAFe Agilist",
+      "ICAgile Certified"
+    ],
+    "industry_verticals": [
+      "Technology",
+      "Financial Services",
+      "Healthcare"
+    ],
+    "capacity": 20,
+    "consultants": [
+      "charlotte.young@slalom.com",
+      "henry.king@slalom.com"
+    ]
+  },
+  "Slalom Build": {
+    "description": "Product strategy, design, agile delivery, and full-stack product development for digital innovation engagements",
+    "practice_area": "Technology",
+    "skill_levels": [
+      "Emerging",
+      "Proficient",
+      "Advanced",
+      "Expert"
+    ],
+    "certifications": [
+      "Product Management Certification",
+      "Certified Scrum Product Owner",
+      "ICAgile Certified"
+    ],
+    "industry_verticals": [
+      "Consumer Products",
+      "Financial Services",
+      "Healthcare"
+    ],
+    "capacity": 30,
+    "consultants": [
+      "marcus.thomas@slalom.com",
+      "zoe.parker@slalom.com"
+    ]
+  }
+}

--- a/src/practice_leads.json
+++ b/src/practice_leads.json
@@ -1,15 +1,13 @@
 {
   "practicelead-tech": {
-    "password_salt": "OKeS5wTB/hROsu5GicBzSQ==",
-    "password_hash": "9LRNFK24zhixT7OPqJb4vyfVRi8s6prfll22e+CZB8I=",
+    "password_env_var": "PRACTICELEAD_TECH_PASSWORD",
     "role": "Practice Lead",
     "practice_areas": [
       "Technology"
     ]
   },
   "practicelead-strategy": {
-    "password_salt": "SaiKiGlF47n1drW8aROcBQ==",
-    "password_hash": "UM7yvjenXbF6OJ4r6iqMeOJJ8hdIv4ZJdAEm72hxFZg=",
+    "password_env_var": "PRACTICELEAD_STRATEGY_PASSWORD",
     "role": "Practice Lead",
     "practice_areas": [
       "Strategy",

--- a/src/practice_leads.json
+++ b/src/practice_leads.json
@@ -1,0 +1,19 @@
+{
+  "practicelead-tech": {
+    "password_salt": "OKeS5wTB/hROsu5GicBzSQ==",
+    "password_hash": "9LRNFK24zhixT7OPqJb4vyfVRi8s6prfll22e+CZB8I=",
+    "role": "Practice Lead",
+    "practice_areas": [
+      "Technology"
+    ]
+  },
+  "practicelead-strategy": {
+    "password_salt": "SaiKiGlF47n1drW8aROcBQ==",
+    "password_hash": "UM7yvjenXbF6OJ4r6iqMeOJJ8hdIv4ZJdAEm72hxFZg=",
+    "role": "Practice Lead",
+    "practice_areas": [
+      "Strategy",
+      "Operations"
+    ]
+  }
+}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,64 @@ document.addEventListener("DOMContentLoaded", () => {
   const capabilitySelect = document.getElementById("capability");
   const registerForm = document.getElementById("register-form");
   const messageDiv = document.getElementById("message");
+  const authStatus = document.getElementById("auth-status");
+  const openLoginButton = document.getElementById("open-login-btn");
+  const logoutButton = document.getElementById("logout-btn");
+  const loginModal = document.getElementById("login-modal");
+  const closeLoginButton = document.getElementById("close-login-btn");
+  const loginForm = document.getElementById("login-form");
+  const loginMessage = document.getElementById("login-message");
+
+  let currentUser = null;
+
+  function showMessage(target, text, type) {
+    target.textContent = text;
+    target.className = type;
+    target.classList.remove("hidden");
+  }
+
+  function hideMessage(target) {
+    target.classList.add("hidden");
+  }
+
+  function canManageCapability(details) {
+    if (!currentUser) {
+      return false;
+    }
+
+    return currentUser.practice_areas.includes("All") ||
+      currentUser.practice_areas.includes(details.practice_area);
+  }
+
+  function updateAuthUI() {
+    if (currentUser) {
+      authStatus.textContent = `${currentUser.role}: ${currentUser.username} (${currentUser.practice_areas.join(", ")})`;
+      openLoginButton.classList.add("hidden");
+      logoutButton.classList.remove("hidden");
+    } else {
+      authStatus.textContent = "Consultant mode";
+      openLoginButton.classList.remove("hidden");
+      logoutButton.classList.add("hidden");
+    }
+  }
+
+  function openLoginModal() {
+    hideMessage(loginMessage);
+    loginModal.classList.remove("hidden");
+  }
+
+  function closeLoginModal() {
+    loginModal.classList.add("hidden");
+    loginForm.reset();
+    hideMessage(loginMessage);
+  }
+
+  async function refreshAuthSession() {
+    const response = await fetch("/auth/session");
+    const result = await response.json();
+    currentUser = result.authenticated ? result.user : null;
+    updateAuthUI();
+  }
 
   // Function to fetch capabilities from API
   async function fetchCapabilities() {
@@ -12,6 +70,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       capabilitiesList.innerHTML = "";
+      capabilitySelect.innerHTML = '<option value="">-- Select a capability --</option>';
 
       // Populate capabilities list
       Object.entries(capabilities).forEach(([name, details]) => {
@@ -30,12 +89,16 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.consultants
                   .map(
                     (email) =>
-                      `<li><span class="consultant-email">${email}</span><button class="delete-btn" data-capability="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="consultant-email">${email}</span>${canManageCapability(details) ? `<button class="delete-btn" data-capability="${name}" data-email="${email}">Remove</button>` : ""}</li>`
                   )
                   .join("")}
               </ul>
             </div>`
             : `<p><em>No consultants registered yet</em></p>`;
+
+        const managementNote = canManageCapability(details)
+          ? '<p class="management-note">You can manage registrations for this practice area.</p>'
+          : '<p class="management-note">Practice lead sign-in is required to remove consultants.</p>';
 
         capabilityCard.innerHTML = `
           <h4>${name}</h4>
@@ -44,6 +107,7 @@ document.addEventListener("DOMContentLoaded", () => {
           <p><strong>Industry Verticals:</strong> ${details.industry_verticals ? details.industry_verticals.join(', ') : 'Not specified'}</p>
           <p><strong>Capacity:</strong> ${availableCapacity} hours/week available</p>
           <p><strong>Current Team:</strong> ${currentConsultants} consultants</p>
+          ${managementNote}
           <div class="consultants-container">
             ${consultantsHTML}
           </div>
@@ -88,26 +152,20 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(messageDiv, result.message, "success");
 
         // Refresh capabilities list to show updated consultants
         fetchCapabilities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(messageDiv, result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
 
       // Hide message after 5 seconds
       setTimeout(() => {
-        messageDiv.classList.add("hidden");
+        hideMessage(messageDiv);
       }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage(messageDiv, "Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -132,31 +190,94 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(messageDiv, result.message, "success");
         registerForm.reset();
 
         // Refresh capabilities list to show updated consultants
         fetchCapabilities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(messageDiv, result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
 
       // Hide message after 5 seconds
       setTimeout(() => {
-        messageDiv.classList.add("hidden");
+        hideMessage(messageDiv);
       }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to register. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage(messageDiv, "Failed to register. Please try again.", "error");
       console.error("Error registering:", error);
     }
   });
 
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: document.getElementById("username").value,
+          password: document.getElementById("password").value,
+        }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(loginMessage, result.detail || "Unable to sign in", "error");
+        return;
+      }
+
+      currentUser = result.user;
+      updateAuthUI();
+      closeLoginModal();
+      showMessage(messageDiv, result.message, "success");
+      fetchCapabilities();
+    } catch (error) {
+      showMessage(loginMessage, "Unable to sign in right now.", "error");
+      console.error("Error signing in:", error);
+    }
+  });
+
+  openLoginButton.addEventListener("click", openLoginModal);
+  closeLoginButton.addEventListener("click", closeLoginModal);
+
+  logoutButton.addEventListener("click", async () => {
+    try {
+      const response = await fetch("/auth/logout", {
+        method: "POST",
+      });
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(messageDiv, result.detail || "Unable to sign out", "error");
+        return;
+      }
+
+      currentUser = null;
+      updateAuthUI();
+      fetchCapabilities();
+      showMessage(messageDiv, result.message, "info");
+    } catch (error) {
+      showMessage(messageDiv, "Unable to sign out right now.", "error");
+      console.error("Error signing out:", error);
+    }
+  });
+
+  loginModal.addEventListener("click", (event) => {
+    if (event.target === loginModal) {
+      closeLoginModal();
+    }
+  });
+
   // Initialize app
-  fetchCapabilities();
+  async function initializeApp() {
+    await refreshAuthSession();
+    await fetchCapabilities();
+  }
+
+  initializeApp();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -9,10 +9,20 @@
   <body>
     <header>
       <div class="header-content">
-        <img src="https://colby-timm.github.io/images/byte-teacher.png" alt="Byte mascot" class="mascot" />
-        <div class="header-text">
-          <h1>Slalom Capabilities Management</h1>
-          <h2>Consulting Expertise Platform</h2>
+        <div class="brand-block">
+          <img src="https://colby-timm.github.io/images/byte-teacher.png" alt="Byte mascot" class="mascot" />
+          <div class="header-text">
+            <h1>Slalom Capabilities Management</h1>
+            <h2>Consulting Expertise Platform</h2>
+          </div>
+        </div>
+        <div class="auth-panel">
+          <p id="auth-status" class="auth-status">Consultant mode</p>
+          <div class="auth-actions">
+            <button id="open-login-btn" type="button" class="secondary-btn">Practice Lead Sign In</button>
+            <button id="logout-btn" type="button" class="secondary-btn hidden">Sign Out</button>
+          </div>
+          <p class="auth-hint">Practice leads can remove consultants from capabilities after signing in.</p>
         </div>
       </div>
     </header>
@@ -45,6 +55,27 @@
         <div id="message" class="hidden"></div>
       </section>
     </main>
+
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-card">
+        <div class="modal-header">
+          <h3>Practice Lead Sign In</h3>
+          <button id="close-login-btn" type="button" class="icon-btn" aria-label="Close sign in dialog">×</button>
+        </div>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required placeholder="practicelead-tech" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required placeholder="Enter password" />
+          </div>
+          <button type="submit">Sign In</button>
+        </form>
+        <div id="login-message" class="hidden"></div>
+      </div>
+    </div>
 
     <footer>
       <div class="footer-content">

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -28,9 +28,42 @@ header {
 .header-content {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   gap: 20px;
   flex-wrap: wrap;
+}
+
+.brand-block {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.auth-panel {
+  min-width: 260px;
+  max-width: 320px;
+  padding: 16px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.12);
+  text-align: left;
+}
+
+.auth-status {
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.auth-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.auth-hint {
+  margin-top: 10px;
+  font-size: 0.9rem;
+  color: #e3f2fd;
 }
 
 .mascot {
@@ -153,7 +186,7 @@ section h3 {
   color: white;
   cursor: pointer;
   font-size: 12px;
-  padding: 4px 8px;
+  padding: 6px 10px;
   transition: all 0.2s;
   border-radius: 4px;
   font-weight: bold;
@@ -206,6 +239,29 @@ button[type="submit"] {
   letter-spacing: 1px;
 }
 
+.secondary-btn,
+.icon-btn {
+  background: white;
+  color: #003d7a;
+  border: none;
+  padding: 10px 14px;
+  font-size: 14px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.secondary-btn:hover,
+.icon-btn:hover {
+  background: #e3f2fd;
+}
+
+.management-note {
+  margin-top: 8px;
+  color: #0054a6;
+  font-size: 0.95rem;
+}
+
 button[type="submit"]:hover {
   background: linear-gradient(135deg, #0066cc, #1976d2);
   transform: translateY(-2px);
@@ -238,6 +294,35 @@ button[type="submit"]:hover {
 
 .hidden {
   display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-card {
+  width: min(100%, 420px);
+  background: white;
+  border-radius: 14px;
+  padding: 24px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.25);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
 }
 
 footer {
@@ -290,6 +375,15 @@ footer {
   .header-content {
     flex-direction: column;
     gap: 10px;
+  }
+
+  .brand-block {
+    flex-direction: column;
+  }
+
+  .auth-panel {
+    width: 100%;
+    max-width: none;
   }
   
   .mascot {


### PR DESCRIPTION
## Summary
Externalize the capability catalog into JSON, add the Slalom Build capability, and introduce a first practice-lead authentication slice for protected consultant removal.

## What changed
- move capability definitions out of `src/app.py` into `src/capabilities.json`
- add the missing `Slalom Build` capability to the shared catalog
- add `practice_leads.json` with practice-lead identities mapped to environment-variable password names
- add login, session, and logout endpoints in the FastAPI app
- require practice-lead authentication and practice-area authorization for unregister actions
- update the frontend with sign-in UI and gated removal controls
- load capability and practice-lead configuration from disk on each request so JSON file edits are reflected without restarting the app
- document the new configuration files and environment-based password setup

## Validation
- verified the app loads the externalized capability catalog
- verified `Slalom Build` is present in the loaded capability list
- verified unauthenticated unregister returns `401`
- verified environment-backed practice-lead login returns `200`
- verified authorized unregister returns `200`
- verified capability JSON updates are observed live without restarting the app

Closes #4
Closes #6
Related to #7